### PR TITLE
Fix deprecation warning

### DIFF
--- a/t/12_send_rich.t
+++ b/t/12_send_rich.t
@@ -52,7 +52,7 @@ send_request {
 
     my $json = $data->{content}{contentMetadata}{MARKUP_JSON};
     like $json, qr!"linkUri":"https://example.com/family/manga/en"!;
-    like $json, qr!"MANGA":{!;
+    like $json, qr!"MANGA":\{!;
     like $json, qr!"action":"MANGA"!;
 
     is_deeply(decode_json($json), {


### PR DESCRIPTION
Fix following warning in test code.

```
Unescaped left brace in regex is deprecated, passed through in regex;
marked by <-- HERE in m/"MANGA":{ <-- HERE / at t/12_send_rich.t line 55.
```