### PR TITLE
Added Perl 5.28 into travis-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: perl
 perl:
+  - 5.28
   - 5.26
   - 5.24
   - 5.22


### PR DESCRIPTION
Since Perl 5.28 has been released, I will add the `.travis.yml`.

- issue #30