### PR TITLE
Include 't/lib' for each test cases.

### DIFF
--- a/t/00_send_message_response.t
+++ b/t/00_send_message_response.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/01_send_text.t
+++ b/t/01_send_text.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/02_send_image.t
+++ b/t/02_send_image.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/03_send_video.t
+++ b/t/03_send_video.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/04_send_audio.t
+++ b/t/04_send_audio.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/05_send_location.t
+++ b/t/05_send_location.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/06_send_sticker.t
+++ b/t/06_send_sticker.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/07_send_imagemap.t
+++ b/t/07_send_imagemap.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/08_send_template.t
+++ b/t/08_send_template.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/11_send_multiple.t
+++ b/t/11_send_multiple.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/12_multicast.t
+++ b/t/12_multicast.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/21_get_profile.t
+++ b/t/21_get_profile.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use JSON::XS;

--- a/t/41_event.t
+++ b/t/41_event.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use LINE::Bot::API::Event;

--- a/t/42_create_events_by_api.t
+++ b/t/42_create_events_by_api.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use lib 't/lib';
 use t::Util;
 
 use LINE::Bot::API;


### PR DESCRIPTION
Since when user run `milla test`, milla doesn't load `.proverc`.