### PR TITLE
[Travis CI] remove osx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 language: perl
 
@@ -18,7 +17,6 @@ script:
   prove -lrv t/
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -L https://install.perlbrew.pl | bash ; source $HOME/perl5/perlbrew/etc/bashrc; perlbrew install -j4 --notest --as perl-$TRAVIS_PERL_VERSION $(perlbrew available | grep $TRAVIS_PERL_VERSION | cut -c4- | head -1); perlbrew clean; perlbrew install-cpanm; perlbrew use "$TRAVIS_PERL_VERSION"; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers; source ~/travis-perl-helpers/init; build-perl; fi
   - perl -V
   - cpanm --notest Test::More~0.98


### PR DESCRIPTION
It takes much longer to run tests on osx/travis-ci since most of the
time we need to wait for perl itself to be installed.

Since most of SDK devs are using macOS, it seems to be a bit wasteful
to also run tests on osx/travis-ci.