### PR TITLE
add an example of using altUri.desktop.

### DIFF
--- a/eg/push-flex-hello.pl
+++ b/eg/push-flex-hello.pl
@@ -50,43 +50,22 @@ my @messages = (
                         "type" => "text",
                         "align" => "end",
                         "text" => "".localtime(),
-                    }
+                    },
+                    +{
+                        "type" => "button",
+                        "style" => "link",
+                        "height" => "sm",
+                        "action" => {
+                            "type" => "uri",
+                            "label" => "URI action sample",
+                            "uri" => "https://example.com",
+                            "altUri" => {
+                                "desktop" => "https://example.com/desktop"
+                            }
+                        }
+                    },
                 ]
             }
-        }
-    },
-    {
-        "type" => "bubble",
-        "body" => {
-            "type" => "box",
-            "layout" => "vertical",
-            "spacing" => "sm",
-            "contents" => [
-                +{
-                    "type" => "button",
-                    "style" => "primary",
-                    "action" => {
-                        "type" => "uri",
-                        "label" => "nyan",
-                        "uri" => "https =>//example.com",
-                        "altUri" => {
-                            "desktop" => "https =>//example.com/desktop"
-                        }
-                    }
-                },
-                +{
-                    "type" => "button",
-                    "style" => "primary",
-                    "action" => {
-                        "type" => "uri",
-                        "label" => "meow",
-                        "uri" => "https =>//example.com",
-                        "altUri" => {
-                            "desktop" => "https =>//example.com/desktop"
-                        }
-                    }
-                }
-            ]
         }
     }
 );

--- a/eg/push-flex-hello.pl
+++ b/eg/push-flex-hello.pl
@@ -78,8 +78,6 @@ my $bot = LINE::Bot::API->new(
     ):(),
 );
 
-my $msg = LINE::Bot::API::Builder::SendMessage->new;
-
 my $res = $bot->push_message($to_id, \@messages);
 
 unless ($res->is_success) {

--- a/eg/push-flex-hello.pl
+++ b/eg/push-flex-hello.pl
@@ -19,19 +19,8 @@ my($to_id) = @ARGV;
 
 $to_id or die "requires \$ARGV[0]: a user ID";
 
-my $bot = LINE::Bot::API->new(
-    channel_secret         => $channel_secret,
-    channel_access_token   => $channel_access_token,
-    $messaging_api_endpoint ? (
-        messaging_api_endpoint => $messaging_api_endpoint,
-    ):(),
-);
-
-my $msg = LINE::Bot::API::Builder::SendMessage->new;
-
-my $res = $bot->push_message(
-    $to_id,
-    [+{
+my @messages = (
+    +{
         type => "flex",
         altText => "Hello World",
         contents => {
@@ -65,8 +54,54 @@ my $res = $bot->push_message(
                 ]
             }
         }
-    }]
+    },
+    {
+        "type" => "bubble",
+        "body" => {
+            "type" => "box",
+            "layout" => "vertical",
+            "spacing" => "sm",
+            "contents" => [
+                +{
+                    "type" => "button",
+                    "style" => "primary",
+                    "action" => {
+                        "type" => "uri",
+                        "label" => "nyan",
+                        "uri" => "https =>//example.com",
+                        "altUri" => {
+                            "desktop" => "https =>//example.com/desktop"
+                        }
+                    }
+                },
+                +{
+                    "type" => "button",
+                    "style" => "primary",
+                    "action" => {
+                        "type" => "uri",
+                        "label" => "meow",
+                        "uri" => "https =>//example.com",
+                        "altUri" => {
+                            "desktop" => "https =>//example.com/desktop"
+                        }
+                    }
+                }
+            ]
+        }
+    }
 );
+
+my $bot = LINE::Bot::API->new(
+    channel_secret         => $channel_secret,
+    channel_access_token   => $channel_access_token,
+    $messaging_api_endpoint ? (
+        messaging_api_endpoint => $messaging_api_endpoint,
+    ):(),
+);
+
+my $msg = LINE::Bot::API::Builder::SendMessage->new;
+
+my $res = $bot->push_message($to_id, \@messages);
 
 unless ($res->is_success) {
     print Dumper([ res => $res ]);


### PR DESCRIPTION
For issue #57 

This attribute is only available in Flex messages and we have decided to represent flex messages as native perl structure (nested HashRef/ArrayRef).

No changes in `lib/` are needed, only add an example.
