### PR TITLE
Requires Type::Tiny at least 1.004000.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,7 +6,7 @@ requires 'Furl';
 requires 'JSON::XS';
 requires 'IO::Socket::SSL';
 requires 'MIME::Base64';
-requires 'Type::Tiny';
+requires 'Type::Tiny', '1.004000';
 
 on test => sub {
     requires 'Test::More';


### PR DESCRIPTION
This should fix: https://github.com/line/line-bot-sdk-perl/issues/96

According to [Changelog][1], StrLength was added in 1.003_002, which was
a DEV release. The next non-DEV release is selected instead.

Here's the related test error found on cpantesters. [Here][2],
[here][3], and [here][4]:

    Could not find sub 'StrLength' exported by Types::Common::String at /home/cpansand/.cpan/build/2019122008/LINE-Bot-API-1.13-2/blib/lib/LINE/Bot/API/Types.pm line 9.
    BEGIN failed--compilation aborted at /home/cpansand/.cpan/build/2019122008/LINE-Bot-API-1.13-2/blib/lib/LINE/Bot/API/Types.pm line 9.
    Compilation failed in require at t/types-validate-examples.t line 11.
    BEGIN failed--compilation aborted at t/types-validate-examples.t line 11.

[1]: https://metacpan.org/changes/distribution/Type-Tiny#L470
[2]: http://cpantesters.org/cpan/report/53545906-2353-11ea-af00-3e6d1f24ea8f
[3]: http://cpantesters.org/cpan/report/595f3802-2353-11ea-af00-3e6d1f24ea8f
[4]: http://cpantesters.org/cpan/report/4ddc721a-2353-11ea-af00-3e6d1f24ea8f