### PR TITLE
Fixing endpoint url for api-data.line.me

### DIFF
--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -305,7 +305,7 @@ sub upload_rich_menu_image {
     }
 
     my $res = $self->{client}->post_image(
-        $self->{content_api_endpoint} . "v2/bot/richmenu/$rich_menu_id/content",
+        $self->{content_api_endpoint} . "richmenu/$rich_menu_id/content",
         [
             'Content-Type' => $content_type,
         ],
@@ -324,7 +324,7 @@ sub download_rich_menu_image {
     my ($self, $rich_menu_id) = @_;
 
     return $self->{client}->get_content(
-        $self->{content_api_endpoint} . "v2/bot/richmenu/$rich_menu_id/content"
+        $self->{content_api_endpoint} . "richmenu/$rich_menu_id/content"
     );
 }
 

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -117,7 +117,7 @@ sub broadcast {
 
 sub get_message_content {
     my($self, $message_id, %options) = @_;
-    my $res = $self->request_content(
+    my $res = $self->request(
         'contents_download' => "message/$message_id/content",
         %options
     );

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -25,7 +25,7 @@ use LINE::Bot::API::Response::NumberOfFollowers;
 use constant {
     DEFAULT_MESSAGING_API_ENDPOINT => 'https://api.line.me/v2/bot/',
     DEFAULT_SOCIAL_API_ENDPOINT    => 'https://api.line.me/v2/oauth/',
-    DEFAULT_CONTENT_API_ENDPOINT   => 'https://api-data.line.me/',
+    DEFAULT_CONTENT_API_ENDPOINT   => 'https://api-data.line.me/v2/bot/',
 };
 use Furl;
 use Carp 'croak';
@@ -117,7 +117,7 @@ sub broadcast {
 
 sub get_message_content {
     my($self, $message_id, %options) = @_;
-    my $res = $self->request(
+    my $res = $self->request_content(
         'contents_download' => "message/$message_id/content",
         %options
     );


### PR DESCRIPTION
This PR is fixing for #108 

Sorry so much for my missing `v2/bot/` for default content api endpoint.

I confirmed can get_message_content works after fixed.
