### PR TITLE
Support LINE Emoji in text message

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension LINE::Bot::API
 
 {{$NEXT}}
+        - Support the use of LINE Emojis in Text messages.
 
 1.16  2020-03-13 17:27:04 JST
         - Fixed bug (Issue #108, PR #112)

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -868,6 +868,27 @@ Build a text type object.
     );
     $bot->reply_message($reply_token, $messages->build);
 
+Build a text message with emojis inside:
+
+    my $message = LINE::Bot::API::Builder::SendMessage->new();
+    $message->add_text(
+        text => '$ LINE Emoji $',
+        emojis => [
+            +{
+                "index" => 0,
+                "productId" => "5ac1bfd5040ab15980c9b435",
+                "emojiId" => "001"
+            },
+            +{
+                "index" => 13,
+                "productId" => "5ac1bfd5040ab15980c9b435",
+                "emojiId" => "002"
+            }
+        ]
+    );
+
+Since 2020/04/16, text messages may contain LINE emojis. They are identified by (productId, emojiId). For more details about possible values as well as how to use these emojis, please read: L<https://developers.line.biz/en/reference/messaging-api/#text-message> first.
+
 =head2 Image type
 
 Build an image type object.

--- a/lib/LINE/Bot/API/Builder/SendMessage.pm
+++ b/lib/LINE/Bot/API/Builder/SendMessage.pm
@@ -23,6 +23,9 @@ sub add_text {
     $self->add(+{
         type => 'text',
         text => $args{text},
+        $args{emojis} ? (
+            emojis => $args{emojis},
+        ):(),
     });
 }
 

--- a/t/01_send_text-with-emoji.t
+++ b/t/01_send_text-with-emoji.t
@@ -1,0 +1,99 @@
+use strict;
+use warnings;
+use Test::More;
+use lib 't/lib';
+use t::Util;
+
+use JSON::XS;
+use LINE::Bot::API;
+use LINE::Bot::API::Builder::SendMessage;
+
+my $bot = LINE::Bot::API->new(
+    channel_secret       => 'testsecret',
+    channel_access_token => 'ACCESS_TOKEN',
+);
+
+my $builder = LINE::Bot::API::Builder::SendMessage->new;
+
+# The example from https://developers.line.biz/en/reference/messaging-api/#text-message
+$builder->add_text(
+    text => '$ LINE emoji $',
+    emojis => [
+        +{
+            "index" => 0,
+            "productId" => "5ac1bfd5040ab15980c9b435",
+            "emojiId" => "001"
+        },
+        +{
+            "index" => 13,
+            "productId" => "5ac1bfd5040ab15980c9b435",
+            "emojiId" => "002"
+        }
+    ]
+);
+
+send_request {
+    my $res = $bot->push_message('DUMMY_ID', $builder->build);
+    isa_ok $res, 'LINE::Bot::API::Response::Common';
+    ok $res->is_success;
+    is $res->http_status, 200;
+} receive_request {
+    my %args = @_;
+    is $args{method}, 'POST';
+    is $args{url},    'https://api.line.me/v2/bot/message/push';
+
+    my $data = decode_json $args{content};
+    is $data->{to}, 'DUMMY_ID';
+    is scalar(@{ $data->{messages} }), 1;
+    my $message = $data->{messages}[0];
+    is $message->{type}, 'text';
+    is $message->{text}, '$ LINE emoji $';
+    ok defined($message->{emojis});
+    is ref($message->{emojis}), 'ARRAY';
+    is ((0+ @{$message->{emojis}}), 2);
+
+    for my $emoji (@{$message->{emojis}}) {
+        is 0+keys(%$emoji), 3;
+        ok defined($emoji->{index});
+        ok defined($emoji->{productId});
+        ok defined($emoji->{emojiId});
+    }
+
+    my $has_header = 0;
+    my @headers = @{ $args{headers} };
+    while (my($key, $value) = splice @headers, 0, 2) {
+        $has_header++ if $key eq 'Authorization' && $value eq 'Bearer ACCESS_TOKEN';
+    }
+    is $has_header, 1;
+
+    +{};
+};
+
+send_request {
+    my $res = $bot->reply_message('DUMMY_TOKEN', $builder->build);
+    isa_ok $res, 'LINE::Bot::API::Response::Common';
+    ok $res->is_success;
+    is $res->http_status, 200;
+} receive_request {
+    my %args = @_;
+    is $args{method}, 'POST';
+    is $args{url},    'https://api.line.me/v2/bot/message/reply';
+
+    my $data = decode_json $args{content};
+    is $data->{replyToken}, 'DUMMY_TOKEN';
+    is scalar(@{ $data->{messages} }), 1;
+    my $message = $data->{messages}[0];
+    is $message->{type}, 'text';
+    ok defined( $message->{emojis} );
+
+    my $has_header = 0;
+    my @headers = @{ $args{headers} };
+    while (my($key, $value) = splice @headers, 0, 2) {
+        $has_header++ if $key eq 'Authorization' && $value eq 'Bearer ACCESS_TOKEN';
+    }
+    is $has_header, 1;
+
+    +{};
+};
+
+done_testing;


### PR DESCRIPTION
This PR implements #119 

The "emojis" attribute is an optional attribute that maps to an array of Emoji object -- which is of type `Dict[index, productId, emojiId]` 

The `index` here refer to the index of `$` character in the `"text"` attribute and users needs to calculate these by themselfs.

We could probably make it easier by calculating those `index` in the program in future releases.
