### PR TITLE
The limit of TextMessage.text is now 5000 characters.

### DIFF
--- a/lib/LINE/Bot/API/Types.pm
+++ b/lib/LINE/Bot/API/Types.pm
@@ -34,8 +34,8 @@ my $ContentProvider = Dict [
     originalContentUrl => Optional[NonEmptyStr],
 ];
 
-# https://developers.line.biz/en/reference/messaging-api/#wh-text
-my $TextMessage = declare TextMessage => as Dict[ id => Str, type => Enum["text"], text => StrLength[1,2000] ];
+# https://developers.line.biz/en/reference/messaging-api/#text-message
+my $TextMessage = declare TextMessage => as Dict[ id => Str, type => Enum["text"], text => StrLength[1,5000] ];
 
 # https://developers.line.biz/en/reference/messaging-api/#wh-image
 my $ImageMessage = declare ImageMessage => as Dict[


### PR DESCRIPTION
In a recent update, this limit is increased from 2000 characters to
be 5000.

See https://developers.line.biz/en/reference/messaging-api/#text-message

This resolve one TODO in #137
