### PR TITLE
Adding some subroutine for channel access token v2.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl extension LINE::Bot::API
 {{$NEXT}}
         - Add method: get_group_summary, get_member_in_group_count, get_member_in_room_count (Issue#141, PR#142)
         - Add method: issue_channel_access_token_v2_1, get_valid_channel_access_token_v2_1 (Issue#118, PR#147)
+
 1.17  2020-06-30 14:00:34 JST
         - Add 'language' accessor to Profile response.
         - Add method: Audience#get_audience_data. (PR#125)

--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@ Revision history for Perl extension LINE::Bot::API
 
 {{$NEXT}}
         - Add method: get_group_summary, get_member_in_group_count, get_member_in_room_count (Issue#141, PR#142)
-
+        - Add method: issue_channel_access_token_v2_1, get_valid_channel_access_token_v2_1 (Issue#118, PR#147)
 1.17  2020-06-30 14:00:34 JST
         - Add 'language' accessor to Profile response.
         - Add method: Audience#get_audience_data. (PR#125)

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -29,6 +29,7 @@ use constant {
     DEFAULT_MESSAGING_API_ENDPOINT => 'https://api.line.me/v2/bot/',
     DEFAULT_SOCIAL_API_ENDPOINT    => 'https://api.line.me/v2/oauth/',
     DEFAULT_CONTENT_API_ENDPOINT   => 'https://api-data.line.me/v2/bot/',
+    DEFAULT_OAUTH2_API_ENDPOINT    => 'https://api.line.me/oauth2/v2.1/',
 };
 use Furl;
 use Carp 'croak';
@@ -45,6 +46,7 @@ sub new {
         messaging_api_endpoint => $args{messaging_api_endpoint} // DEFAULT_MESSAGING_API_ENDPOINT,
         social_api_endpoint    => $args{social_api_endpoint} // DEFAULT_SOCIAL_API_ENDPOINT,
         content_api_endpoint => $args{content_api_endpoint} // DEFAULT_CONTENT_API_ENDPOINT,
+        oauth_api_endpoint => $args{oauth_api_endpoint} // DEFAULT_OAUTH2_API_ENDPOINT,
     }, $class;
 }
 
@@ -376,7 +378,7 @@ sub issue_channel_access_token_v2_1 {
     my ($self, $opts) = @_;
 
     my $res = $self->{client}->post_form(
-        $self->{social_api_endpoint} . 'accessToken',
+        $self->{oauth_api_endpoint} . 'token',
         undef,
         [
             grant_type              => 'client_credentials',
@@ -893,6 +895,22 @@ The argument is a HashRef with two pairs of mandatary key-values:
 Both pieces of information can be accquired from the L<channel console|client_id>.
 
 When a 200 OK HTTP response is returned, a new token is issued. In this case, you may want to store the values in "access_token", "expires_in", and "token_type" attributes of the response object for future use.
+
+Otherwise, you my examine the "error" attribute and "error_description" attribute for more information about the error.
+
+=head2 C<< issue_channel_access_token_v2_1({ jwt => '...' }) >>
+
+This method corresponds to the API of: L<Issue Channel access token v2.1|https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1>
+
+The argument is a HashRef with a pair of mandatary key-values:
+
+    {
+        jwt => "...",
+    }
+
+This method lets you use JWT assertion for authentication.
+
+When a 200 OK HTTP response is returned, a new token is issued. In this case, you may want to store the values in "access_token", "expires_in", "token_type" and "key_id" attributes of the response object for future use.
 
 Otherwise, you my examine the "error" attribute and "error_description" attribute for more information about the error.
 

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -920,7 +920,7 @@ Otherwise, you my examine the "error" attribute and "error_description" attribut
 
 This method corresponds to the API of: L<Issue Channel access token v2.1|https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1>
 
-The argument is a HashRef with a pair of mandatary key-values:
+The argument is a HashRef with a pair of mandatory key-values:
 
     {
         jwt => "...",
@@ -936,7 +936,7 @@ Otherwise, you may examine the "error" attribute and "error_description" attribu
 
 This method corresponds to the API of: L<Get all valid channel access token key IDs v2.1|https://developers.line.biz/en/reference/messaging-api/#get-all-valid-channel-access-token-key-ids-v2-1>
 
-The argument is a HashRef with a pair of mandatary key-values:
+The argument is a HashRef with a pair of mandatory key-values:
 
     {
         jwt => "...",

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -930,7 +930,23 @@ This method lets you use JWT assertion for authentication.
 
 When a 200 OK HTTP response is returned, a new token is issued. In this case, you may want to store the values in "access_token", "expires_in", "token_type" and "key_id" attributes of the response object for future use.
 
-Otherwise, you my examine the "error" attribute and "error_description" attribute for more information about the error.
+Otherwise, you may examine the "error" attribute and "error_description" attribute for more information about the error.
+
+=head2 C<< get_valid_channel_access_token_v2_1({ jwt => '...' }) >>
+
+This method corresponds to the API of: L<Get all valid channel access token key IDs v2.1|https://developers.line.biz/en/reference/messaging-api/#get-all-valid-channel-access-token-key-ids-v2-1>
+
+The argument is a HashRef with a pair of mandatary key-values:
+
+    {
+        jwt => "...",
+    }
+
+This method is for getting all valid channel access token key IDs.
+
+When a 200 OK HTTP response is returned, a new token is issued. In this case, you may want to store the values in "key_ids" attributes of the response object for future use.
+
+Otherwise, you may examine the "error" attribute and "error_description" attribute for more information about the error.
 
 =head2 C<< revoke_channel_access_token({ access_token => "..." }) >>
 

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -372,16 +372,16 @@ sub issue_channel_access_token {
     }
 }
 
-sub issue_channel_access_token_v_2_1 {
+sub issue_channel_access_token_v2_1 {
     my ($self, $opts) = @_;
 
     my $res = $self->{client}->post_form(
         $self->{social_api_endpoint} . 'accessToken',
         undef,
         [
-            grant_type    => 'client_credentials',
-            client_id     => $opts->{client_id},
-            client_secret => $opts->{client_secret},
+            grant_type              => 'client_credentials',
+            client_assertion_type   => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            client_assertion        => $opts->{jwt},
         ]
     );
 

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -372,6 +372,26 @@ sub issue_channel_access_token {
     }
 }
 
+sub issue_channel_access_token_v_2_1 {
+    my ($self, $opts) = @_;
+
+    my $res = $self->{client}->post_form(
+        $self->{social_api_endpoint} . 'accessToken',
+        undef,
+        [
+            grant_type    => 'client_credentials',
+            client_id     => $opts->{client_id},
+            client_secret => $opts->{client_secret},
+        ]
+    );
+
+    if ($res->{http_status} eq '200') {
+        return LINE::Bot::API::Response::Token->new(%{ $res });
+    } else {
+        return LINE::Bot::API::Response::Error->new(%{ $res });
+    }
+}
+
 sub revoke_channel_access_token {
     my ($self, $opts) = @_;
 

--- a/lib/LINE/Bot/API.pm
+++ b/lib/LINE/Bot/API.pm
@@ -33,6 +33,7 @@ use constant {
 };
 use Furl;
 use Carp 'croak';
+use URI::Escape;
 
 sub new {
     my($class, %args) = @_;
@@ -385,6 +386,23 @@ sub issue_channel_access_token_v2_1 {
             client_assertion_type   => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
             client_assertion        => $opts->{jwt},
         ]
+    );
+
+    if ($res->{http_status} eq '200') {
+        return LINE::Bot::API::Response::Token->new(%{ $res });
+    } else {
+        return LINE::Bot::API::Response::Error->new(%{ $res });
+    }
+}
+
+sub get_valid_channel_access_token_v2_1 {
+    my ($self, $opts) = @_;
+
+    my $jwt = uri_escape($opts->{jwt});
+    my $assertion_type = uri_escape('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+
+    my $res = $self->{client}->get(
+        $self->{oauth_api_endpoint} . 'tokens/kid' . "?client_assertion_type=$assertion_type&client_assertion=$jwt",
     );
 
     if ($res->{http_status} eq '200') {

--- a/lib/LINE/Bot/API/Response/Token.pm
+++ b/lib/LINE/Bot/API/Response/Token.pm
@@ -11,4 +11,6 @@ sub token_type { $_[0]->{token_type} }
 sub expires_in { $_[0]->{expires_in} }
 sub key_id { $_[0]->{key_id} }
 
+sub key_ids { $_[0]->{key_ids}}
+
 1;

--- a/lib/LINE/Bot/API/Response/Token.pm
+++ b/lib/LINE/Bot/API/Response/Token.pm
@@ -8,4 +8,7 @@ sub access_token { $_[0]->{access_token} }
 sub expires_in { $_[0]->{expires_in} }
 sub token_type { $_[0]->{token_type} }
 
+sub expires_in { $_[0]->{expires_in} }
+sub key_id { $_[0]->{key_id} }
+
 1;

--- a/t/oauth.t
+++ b/t/oauth.t
@@ -5,6 +5,8 @@ use lib 't/lib';
 use t::Util;
 
 use JSON::XS qw(decode_json);
+use URI::Escape;
+
 use LINE::Bot::API;
 
 
@@ -109,6 +111,46 @@ subtest 'issue channel access token v2.1 (successful case)' => sub {
             expires_in      => 2592000,
             token_type      => 'Bearer',
             key_id          => 'dummy_key_id',
+        };
+    };
+};
+
+subtest 'get valid channel access token v2.1' => sub {
+
+    my $dummy_result = [
+        "U_gdnFYKTWRxxxxDVZexGg",
+        "sDTOzw5wIfWxxxxzcmeQA",
+        "73hDyp3PxGfxxxxD6U5qYA",
+        "FHGanaP79smDxxxxyPrVw",
+        "CguB-0kxxxxdSM3A5Q_UtQ",
+        "G82YP96jhHwyKSxxxx7IFA"
+    ];
+
+    send_request {
+        my $res = $bot->get_valid_channel_access_token_v2_1({ jwt => 'DUMMY_JWT' });
+
+        ok $res->is_success;
+        is $res->http_status, 200;
+
+        is_deeply($res->key_ids, $dummy_result);
+
+    } receive_request {
+        my %args = @_;
+        is $args{method}, 'GET';
+
+        my $jwt = uri_escape('DUMMY_JWT');
+        my $assertion_type = uri_escape('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+        is $args{url},    'https://api.line.me/oauth2/v2.1/tokens/kid' . "?client_assertion_type=$assertion_type&client_assertion=$jwt";
+
+        return +{
+            key_ids => [
+                "U_gdnFYKTWRxxxxDVZexGg",
+                "sDTOzw5wIfWxxxxzcmeQA",
+                "73hDyp3PxGfxxxxD6U5qYA",
+                "FHGanaP79smDxxxxyPrVw",
+                "CguB-0kxxxxdSM3A5Q_UtQ",
+                "G82YP96jhHwyKSxxxx7IFA"
+            ]
         };
     };
 };

--- a/t/oauth.t
+++ b/t/oauth.t
@@ -79,4 +79,38 @@ subtest 'renew access token (error case)', sub {
     };
 };
 
+subtest 'issue channel access token v2.1 (successful case)' => sub {
+    send_request {
+        my $res = $bot->issue_channel_access_token_v2_1({ jwt => 'DUMMY_JWT' });
+
+        ok $res->is_success;
+        is $res->http_status, 200;
+
+        is $res->access_token,  'NEWTOKEN';
+        is $res->expires_in,    '2592000';
+        is $res->token_type,    'Bearer';
+        is $res->key_id,        'dummy_key_id'
+    } receive_request {
+        my %args = @_;
+        is $args{method}, 'POST';
+        is $args{url},    'https://api.line.me/oauth2/v2.1/token';
+
+        my @contents = @{$args{content} // ''};
+        my $has_header = 0;
+        while (my($key, $value) = splice @contents, 0, 2) {
+            $has_header++ if $key eq 'grant_type' && $value eq 'client_credentials';
+            $has_header++ if $key eq 'client_assertion_type' && $value eq 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+            $has_header++ if $key eq 'client_assertion' && $value eq 'DUMMY_JWT';
+        }
+        is $has_header, 3;
+
+        return +{
+            access_token    => 'NEWTOKEN',
+            expires_in      => 2592000,
+            token_type      => 'Bearer',
+            key_id          => 'dummy_key_id',
+        };
+    };
+};
+
 done_testing;


### PR DESCRIPTION
This PR is for issue #118 .
I consider to add subroutine for below.
- [Issuing channel access token v2.1](https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1)
- [Getting all valid channel access token key IDs v2.1](https://developers.line.biz/en/reference/messaging-api/#get-all-valid-channel-access-token-key-ids-v2-1)