### PR TITLE
Adding to support events of "unsend" and "video viewing complete"

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@ Revision history for Perl extension LINE::Bot::API
         - Add method: get_group_summary, get_member_in_group_count, get_member_in_room_count (Issue#141, PR#142)
         - Add method: issue_channel_access_token_v2_1, get_valid_channel_access_token_v2_1 (Issue#118, PR#147)
         - Add support for retrying with "X-Line-Retry-Key" HTTP header for push messages, broadcast, multicast, and narrowcast. (PR #146). See https://developers.line.biz/en/reference/messaging-api/#retry-api-request
-        - Add support unsend-event and videoPlayComplete-event (PR #154)
+        - Add support unsend-event and video_viewing_complete-event (PR #154)
 
 1.17  2020-06-30 14:00:34 JST
         - Add 'language' accessor to Profile response.

--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@ Revision history for Perl extension LINE::Bot::API
         - Add method: get_group_summary, get_member_in_group_count, get_member_in_room_count (Issue#141, PR#142)
         - Add method: issue_channel_access_token_v2_1, get_valid_channel_access_token_v2_1 (Issue#118, PR#147)
         - Add support for retrying with "X-Line-Retry-Key" HTTP header for push messages, broadcast, multicast, and narrowcast. (PR #146). See https://developers.line.biz/en/reference/messaging-api/#retry-api-request
-        - Add support unsend-event (PR #154)
+        - Add support unsend-event and videoPlayComplete-event (PR #154)
 
 1.17  2020-06-30 14:00:34 JST
         - Add 'language' accessor to Profile response.

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for Perl extension LINE::Bot::API
         - Add method: get_group_summary, get_member_in_group_count, get_member_in_room_count (Issue#141, PR#142)
         - Add method: issue_channel_access_token_v2_1, get_valid_channel_access_token_v2_1 (Issue#118, PR#147)
         - Add support for retrying with "X-Line-Retry-Key" HTTP header for push messages, broadcast, multicast, and narrowcast. (PR #146). See https://developers.line.biz/en/reference/messaging-api/#retry-api-request
+        - Add support unsend-event (PR #154)
 
 1.17  2020-06-30 14:00:34 JST
         - Add 'language' accessor to Profile response.

--- a/lib/LINE/Bot/API/Types.pm
+++ b/lib/LINE/Bot/API/Types.pm
@@ -221,4 +221,14 @@ declare UnsendEvent => as Dict[
     @__common__,
 ];
 
+# https://developers.line.biz/en/reference/messaging-api/#video-viewing-complete
+declare VideoViewingCompleteEvent => as Dict[
+    type    => Enum["videoPlayComplete"],
+    replyToken  => Str,
+    videoPlayComplete   => Dict [
+        trackingId  => Str,
+    ],
+    @__common__,
+];
+
 1;

--- a/lib/LINE/Bot/API/Types.pm
+++ b/lib/LINE/Bot/API/Types.pm
@@ -212,4 +212,13 @@ declare DeviceUnlinkEvent => as Dict[
     @__common__,
 ];
 
+# https://developers.line.biz/en/reference/messaging-api/#unsend-event
+declare DeviceUnlinkEvent => as Dict[
+    type       => Enum["unsend"],
+    unsend     => Dict [
+        messageId => Str,
+    ],
+    @__common__,
+];
+
 1;

--- a/lib/LINE/Bot/API/Types.pm
+++ b/lib/LINE/Bot/API/Types.pm
@@ -213,7 +213,7 @@ declare DeviceUnlinkEvent => as Dict[
 ];
 
 # https://developers.line.biz/en/reference/messaging-api/#unsend-event
-declare DeviceUnlinkEvent => as Dict[
+declare UnsendEvent => as Dict[
     type       => Enum["unsend"],
     unsend     => Dict [
         messageId => Str,


### PR DESCRIPTION
This PR is for a few of issue #149 .

my branch name is `unsend_event_support`, but I added support events of `unsend` and `vide viewing complete`.
This branch naming is my bad. Sorry.