### PR TITLE
Remove the duplicated definition of `expires_in`

### DIFF
--- a/lib/LINE/Bot/API/Response/Token.pm
+++ b/lib/LINE/Bot/API/Response/Token.pm
@@ -7,8 +7,6 @@ use parent 'LINE::Bot::API::Response::Common';
 sub access_token { $_[0]->{access_token} }
 sub expires_in { $_[0]->{expires_in} }
 sub token_type { $_[0]->{token_type} }
-
-sub expires_in { $_[0]->{expires_in} }
 sub key_id { $_[0]->{key_id} }
 
 sub key_ids { $_[0]->{key_ids}}


### PR DESCRIPTION
Fixes #164